### PR TITLE
hopefully fix struct tcphdr breakage introduced with golibpcap#13

### DIFF
--- a/pcap/pkt/pkt_unsafe_bsd.go
+++ b/pcap/pkt/pkt_unsafe_bsd.go
@@ -29,12 +29,3 @@ func getPaylen(iphdr *C.struct_ip) uint16 {
 func getProtocol(iphdr *C.struct_ip) uint8 {
 	return uint8(iphdr.ip_p)
 }
-
-func unwrapHeaders(packet *TcpPacket, iphdr *C.struct_ip, tcphdr *C.struct_tcphdr) {
-	packet.DstAddr = uint32(iphdr.ip_dst.s_addr)
-	packet.SrcAddr = uint32(iphdr.ip_src.s_addr)
-	packet.AckSeq = uint32(tcphdr.th_ack)
-	packet.Seq = uint32(tcphdr.th_seq)
-	packet.Source = uint16(tcphdr.th_sport)
-	packet.Dest = uint16(tcphdr.th_dport)
-}

--- a/pcap/pkt/pkt_unsafe_linux.go
+++ b/pcap/pkt/pkt_unsafe_linux.go
@@ -25,12 +25,3 @@ func getPaylen(iphdr *C.struct_iphdr) uint16 {
 func getProtocol(iphdr *C.struct_iphdr) uint8 {
 	return uint8(iphdr.protocol)
 }
-
-func unwrapHeaders(packet *TcpPacket, iphdr *C.struct_iphdr, tcphdr *C.struct_tcphdr) {
-	packet.DstAddr = uint32(iphdr.daddr)
-	packet.SrcAddr = uint32(iphdr.saddr)
-	packet.AckSeq = uint32(tcphdr.ack_seq)
-	packet.Seq = uint32(tcphdr.seq)
-	packet.Source = uint16(tcphdr.source)
-	packet.Dest = uint16(tcphdr.dest)
-}


### PR DESCRIPTION
Added a struct tcphdr replacement, gen_tcphdr, compatible with cgo.
