### PR TITLE
Support zerocopy + bugfix

### DIFF
--- a/pcap/libpcap.c
+++ b/pcap/libpcap.c
@@ -5,13 +5,12 @@
 // These are definitions that pcap.go needs.
 #include "libpcap.h"
 
-// Calls the exported goCallBack function.
-void callback(u_char *args, const struct pcap_pkthdr *header,
-    const u_char *packet) {
-  goCallBack(args, (struct pcap_pkthdr *)header, (u_char *)packet);
+// Gets us the C function pointers that we need.
+
+pt2cb getCallbackChan() {
+  return (pt2cb)goCallbackChan;
 }
 
-// Gets us the C function pointer that we need.
-pt2cb getCallback(){
-  return &callback;
+pt2cb getCallbackLoop() {
+  return (pt2cb)goCallbackLoop;
 }

--- a/pcap/libpcap.h
+++ b/pcap/libpcap.h
@@ -7,12 +7,11 @@
 #include "pcap.h"
 
 // Defined in pcap.go
-extern void goCallBack(u_char *, struct pcap_pkthdr *, u_char *);
-
-// Calls the exported goCallBack function.
-void callback(u_char *, const struct pcap_pkthdr *, const u_char *);
+extern void goCallbackChan(u_char *, struct pcap_pkthdr *, u_char *);
+extern void goCallbackLoop(u_char *, struct pcap_pkthdr *, u_char *);
 
 typedef void(*pt2cb)(u_char *, const struct pcap_pkthdr *, const u_char *);
 
-// Gets us the C function pointer that we need.
-pt2cb getCallback();
+// Gets us the C function pointers that we need.
+pt2cb getCallbackChan();
+pt2cb getCallbackLoop();


### PR DESCRIPTION
- NewPacket2 supported DLT_EN10MB packets, and DLT_LINUX_SLL seemed to work most of the time... 95% of the time in a test system, with 5% packet loss in live tests.
- LoopWithCallback as an alternative to NextEx2.  It enables the zerocopy path of libpcap 1.5.0+, even if it's a little more cumbersome to use.

ping @ElPeque 
