### PR TITLE
add a version of LoopWithCallback that works with a fixed packet in Pcap struct

### DIFF
--- a/pcap/libpcap.c
+++ b/pcap/libpcap.c
@@ -14,3 +14,7 @@ pt2cb getCallbackChan() {
 pt2cb getCallbackLoop() {
   return (pt2cb)goCallbackLoop;
 }
+
+pt2cb getCallbackLoopAllocless() {
+  return (pt2cb)goCallbackLoopAllocless;
+}

--- a/pcap/libpcap.h
+++ b/pcap/libpcap.h
@@ -9,9 +9,11 @@
 // Defined in pcap.go
 extern void goCallbackChan(u_char *, struct pcap_pkthdr *, u_char *);
 extern void goCallbackLoop(u_char *, struct pcap_pkthdr *, u_char *);
+extern void goCallbackLoopAllocless(u_char *, struct pcap_pkthdr *, u_char *);
 
 typedef void(*pt2cb)(u_char *, const struct pcap_pkthdr *, const u_char *);
 
 // Gets us the C function pointers that we need.
 pt2cb getCallbackChan();
 pt2cb getCallbackLoop();
+pt2cb getCallbackLoopAllocless();


### PR DESCRIPTION
Sometimes we process packets right away, others we need to keep it after returning from callbacks.

LoopWithCallback delivers a newly allocated pkt.TcpPacket to the callback, and we need to call Save() if we plan to keep it.

This PR introduces an alloc-less variation of LoopWithCallback, that does not allow to keep a ref to packets as they are reused.
But you can Clone() it.

@potocnyj want to review?
