### PR TITLE
basic IPv6 support

### DIFF
--- a/pcap/pcap.go
+++ b/pcap/pcap.go
@@ -61,7 +61,7 @@ func goCallbackLoop(user *C.u_char, pkthdr_ptr *C.struct_pcap_pkthdr, buf_ptr *C
 	if p.datalinkType == 0 {
 		p.datalinkType = p.Datalink()
 	}
-	if packet, err := pkt.NewPacket2(unsafe.Pointer(pkthdr_ptr), unsafe.Pointer(buf_ptr), p.datalinkType); err == nil {
+	if packet := pkt.NewPacket2(unsafe.Pointer(pkthdr_ptr), unsafe.Pointer(buf_ptr), p.datalinkType); packet != nil {
 		if p.loopCallback(packet) {
 			p.BreakLoop()
 		}
@@ -364,15 +364,13 @@ func (p *Pcap) NextEx() (*pkt.Packet, int32) {
 func (p *Pcap) NextEx2() (pkt.TcpPacket, int32) {
 	var pkthdr_ptr *C.struct_pcap_pkthdr
 	var buf_ptr *C.u_char
-	var packet *pkt.TcpPacket
-	var err error
 	res := int32(C.pcap_next_ex(p.cptr, &pkthdr_ptr, &buf_ptr))
 	if res == 1 {
 		p.pktCnt++
 		if p.datalinkType == 0 {
 			p.datalinkType = p.Datalink()
 		}
-		if packet, err = pkt.NewPacket2(unsafe.Pointer(pkthdr_ptr), unsafe.Pointer(buf_ptr), p.datalinkType); err == nil {
+		if packet := pkt.NewPacket2(unsafe.Pointer(pkthdr_ptr), unsafe.Pointer(buf_ptr), p.datalinkType); packet != nil {
 			return *packet, res
 		}
 		res = 0

--- a/pcap/pkt/pkt_unsafe.go
+++ b/pcap/pkt/pkt_unsafe.go
@@ -15,7 +15,7 @@ package pkt
 #include <netinet/if_ether.h>
 #include <netinet/tcp.h>
 
-// linux cookied header
+// linux cooked header
 struct gen_sll {
 	u_int16_t pkt_type;
 	u_int16_t addr_type;


### PR DESCRIPTION
Add basic (no options / additional headers supported) IPv6.  Both Linux cooked & ethernet DLTs.

Note that this breaks backwards compatibility, as TcpPacket didn't fit the longer addresses.

ping @potocnyj